### PR TITLE
doc: Add srilm_root to .speechrc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ extrasdir_en          = /home/bofh/projects/ai/data/speech/en/kitchen
 librivoxdir           = /home/bofh/projects/ai/data/speech/en/lsvf
 
 kaldi_root            = /apps/kaldi-cuda
+srilm_root            = /apps/kaldi-cuda/tools/srilm
 
 wav16_dir_de          = /home/bofh/projects/ai/data/speech/de/16kHz
 wav16_dir_en          = /home/bofh/projects/ai/data/speech/en/16kHz


### PR DESCRIPTION
The script [speech_build_lm.py](https://github.com/gooofy/speech/blob/7973890b6ce2e3e709ed642c715a2c96f9d9b505/speech_build_lm.py#L80) requires the configuration variable `srilm_root`. Otherwise, running it yields

    Traceback (most recent call last):
      File "./speech_build_lm.py", line 81, in <module>
        srilm_root       = config.get("speech", "srilm_root")
      File "/home/ubuntu/anaconda3/envs/tensorflow_p27/lib/python2.7/ConfigParser.py", line 618, in get
        raise NoOptionError(option, section)
    ConfigParser.NoOptionError: No option 'srilm_root' in section: 'speech'