### PR TITLE
doc: Add sox as requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Requirements
 * srilm
 * kaldi
 * py-nltools
+* sox
 
 Setup Notes
 ===========


### PR DESCRIPTION
Sox is used in [speech_audio_scan.py](https://github.com/gooofy/speech/blob/bdc33c1f1054aa81dc123f8e9bfe953391d58526/speech_audio_scan.py#L123) to convert wav and flac files to wav files.