### PR TITLE
fix: Replace 'mkdir $DIR' with 'mkdir -p $DIR'

### DIFF
--- a/speech_dist.sh
+++ b/speech_dist.sh
@@ -9,7 +9,7 @@ LANG=$1
 DISTDIR=data/dist/$LANG
 
 # rm -rf $DISTDIR
-# mkdir $DISTDIR
+# mkdir -p $DISTDIR
 
 datum=`date +%Y%m%d`
 
@@ -19,14 +19,14 @@ datum=`date +%Y%m%d`
 
 AMNAME="kaldi-chain-voxforge-${LANG}-r$datum"
 
-mkdir "$DISTDIR/$AMNAME"
+mkdir -p "$DISTDIR/$AMNAME"
 
 function export_kaldi_chain {
 
     EXPNAME=$1
     GRAPHNAME=$2
 
-    mkdir "$DISTDIR/$AMNAME/$EXPNAME"
+    mkdir -p "$DISTDIR/$AMNAME/$EXPNAME"
 
     cp data/dst/speech/${LANG}/kaldi/exp/nnet3_chain/$EXPNAME/final.mdl                  $DISTDIR/$AMNAME/$EXPNAME/
     cp data/dst/speech/${LANG}/kaldi/exp/nnet3_chain/$EXPNAME/cmvn_opts                  $DISTDIR/$AMNAME/$EXPNAME/ 2>/dev/null 
@@ -41,7 +41,7 @@ function export_kaldi_chain {
 export_kaldi_chain tdnn_sp tdnn_sp/graph
 export_kaldi_chain tdnn_250 tdnn_250/graph
 
-mkdir "$DISTDIR/$AMNAME/extractor"
+mkdir -p "$DISTDIR/$AMNAME/extractor"
 
 cp data/dst/speech/${LANG}/kaldi/exp/nnet3_chain/extractor/final.mat                  "$DISTDIR/$AMNAME/extractor/"
 cp data/dst/speech/${LANG}/kaldi/exp/nnet3_chain/extractor/global_cmvn.stats          "$DISTDIR/$AMNAME/extractor/"
@@ -55,7 +55,7 @@ cp README.md "$DISTDIR/$AMNAME"
 cp LICENSE   "$DISTDIR/$AMNAME"
 cp AUTHORS   "$DISTDIR/$AMNAME"
 
-mkdir "$DISTDIR/$AMNAME/conf"
+mkdir -p "$DISTDIR/$AMNAME/conf"
 cp data/src/speech/kaldi-mfcc.conf        $DISTDIR/$AMNAME/conf/mfcc.conf 
 cp data/src/speech/kaldi-mfcc-hires.conf  $DISTDIR/$AMNAME/conf/mfcc-hires.conf  
 cp data/src/speech/kaldi-online-cmvn.conf $DISTDIR/$AMNAME/conf/online_cmvn.conf
@@ -76,8 +76,8 @@ exit 0
 
 AMNAME="cmusphinx-cont-voxforge-${LANG}-r$datum"
 
-mkdir "$DISTDIR/$AMNAME"
-mkdir "$DISTDIR/$AMNAME/model_parameters"
+mkdir -p "$DISTDIR/$AMNAME"
+mkdir -p "$DISTDIR/$AMNAME/model_parameters"
 
 cp -r data/dst/speech/${LANG}/cmusphinx_cont/model_parameters/voxforge.cd_cont_6000 "$DISTDIR/$AMNAME/model_parameters"
 cp -r data/dst/speech/${LANG}/cmusphinx_cont/etc "$DISTDIR/$AMNAME"
@@ -99,8 +99,8 @@ rm -r "$DISTDIR/$AMNAME"
 
 AMNAME="cmusphinx-ptm-voxforge-${LANG}-r$datum"
 
-mkdir "$DISTDIR/$AMNAME"
-mkdir "$DISTDIR/$AMNAME/model_parameters"
+mkdir -p "$DISTDIR/$AMNAME"
+mkdir -p "$DISTDIR/$AMNAME/model_parameters"
 
 cp -r data/dst/speech/${LANG}/cmusphinx_ptm/model_parameters/voxforge.cd_ptm_5000 "$DISTDIR/$AMNAME/model_parameters"
 cp -r data/dst/speech/${LANG}/cmusphinx_ptm/etc "$DISTDIR/$AMNAME"
@@ -166,14 +166,14 @@ exit 0
 
 AMNAME="kaldi-nnet3-voxforge-${LANG}-r$datum"
 
-mkdir "$DISTDIR/$AMNAME"
+mkdir -p "$DISTDIR/$AMNAME"
 
 function export_kaldi_nnet3 {
 
     EXPNAME=$1
     GRAPHNAME=$2
 
-    mkdir "$DISTDIR/$AMNAME/$EXPNAME"
+    mkdir -p "$DISTDIR/$AMNAME/$EXPNAME"
 
     cp data/dst/speech/${LANG}/kaldi/exp/nnet3/$EXPNAME/final.mdl                  $DISTDIR/$AMNAME/$EXPNAME/
     cp data/dst/speech/${LANG}/kaldi/exp/nnet3/$EXPNAME/cmvn_opts                  $DISTDIR/$AMNAME/$EXPNAME/ 2>/dev/null 
@@ -188,7 +188,7 @@ function export_kaldi_nnet3 {
 export_kaldi_nnet3 nnet_tdnn_a  nnet_tdnn_a/graph
 # export_kaldi_nnet3 lstm_ld5     lstm_ld5/graph
 
-mkdir "$DISTDIR/$AMNAME/extractor"
+mkdir -p "$DISTDIR/$AMNAME/extractor"
 
 cp data/dst/speech/${LANG}/kaldi/exp/nnet3/extractor/final.mat            "$DISTDIR/$AMNAME/extractor/"
 cp data/dst/speech/${LANG}/kaldi/exp/nnet3/extractor/global_cmvn.stats    "$DISTDIR/$AMNAME/extractor/"
@@ -202,7 +202,7 @@ cp README.md "$DISTDIR/$AMNAME"
 cp LICENSE   "$DISTDIR/$AMNAME"
 cp AUTHORS   "$DISTDIR/$AMNAME"
 
-mkdir "$DISTDIR/$AMNAME/conf"
+mkdir -p "$DISTDIR/$AMNAME/conf"
 cp data/src/speech/kaldi-mfcc.conf        $DISTDIR/$AMNAME/conf/mfcc.conf 
 cp data/src/speech/kaldi-mfcc-hires.conf  $DISTDIR/$AMNAME/conf/mfcc-hires.conf  
 cp data/src/speech/kaldi-online-cmvn.conf $DISTDIR/$AMNAME/conf/online_cmvn.conf


### PR DESCRIPTION
Before the fix the script `speech_dist.sh` failed with the following error message:

```
(tensorflow_p27) ubuntu@ip-172-31-35-114:/kaldi-experiments/speech$ ./speech_dist.sh de
mkdir: cannot create directory 'data/dist/de/kaldi-chain-voxforge-de-r20180119': No such file or directory
mkdir: cannot create directory 'data/dist/de/kaldi-chain-voxforge-de-r20180119/tdnn_sp': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/tdnn_sp/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/tdnn_sp/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/tdnn_sp/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/tdnn_sp/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/tdnn_sp/': No such file or directory
mkdir: cannot create directory 'data/dist/de/kaldi-chain-voxforge-de-r20180119/tdnn_250': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/tdnn_250/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/tdnn_250/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/tdnn_250/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/tdnn_250/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/tdnn_250/': No such file or directory
mkdir: cannot create directory 'data/dist/de/kaldi-chain-voxforge-de-r20180119/extractor': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/extractor/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/extractor/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/extractor/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/extractor/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/extractor/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/extractor/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119': No such file or directory
mkdir: cannot create directory 'data/dist/de/kaldi-chain-voxforge-de-r20180119/conf': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/conf/mfcc.conf': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/conf/mfcc-hires.conf': No such file or directory
cp: cannot create regular file 'data/dist/de/kaldi-chain-voxforge-de-r20180119/conf/online_cmvn.conf': No such file or directory
./speech_dist.sh: line 63: pushd: data/dist/de: No such file or directory
tar: kaldi-chain-voxforge-de-r20180119: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
kaldi-chain-voxforge-de-r20180119.tar (1/1)
  100 %            116 B / 10.0 KiB = 0.011                                    
./speech_dist.sh: line 66: popd: directory stack empty
rm: cannot remove 'data/dist/de/kaldi-chain-voxforge-de-r20180119': No such file or directory
```

The reason is that `mkdir` was told to create the directory `data/dist/de/kaldi-chain-voxforge-de-r20180119`, but `dist/` under `data/` didn't exist yet. The flag `-p` tells `mkdir` to create parent directories as needed.

Without checking if it's really necessary, I've added `-p` to all occurrences of `mkdir`, but there should be no downside.